### PR TITLE
Replace time.time with time.perf_counter

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -515,7 +515,7 @@ def print_status():
     print("Timeouts:", TIMEOUTS)
     print("Ignored:", OPTION_ERRORS)
     print()
-    print("Time taken:{:.2f}s".format(time.time() - START))
+    print("Time taken:{:.2f}s".format(time.perf_counter() - START))
 
 
 def find_hook(hook_path):
@@ -759,7 +759,7 @@ if __name__ == "__main__":
         multiprocessing.set_start_method(start_method)
         tmp = tempfile.TemporaryDirectory(prefix="apfuzz")
         with Pool(processes=args.jobs, maxtasksperchild=None) as p:
-            START = time.time()
+            START = time.perf_counter()
             main(p, args, tmp.name)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
The timer used for `time.time` is not guaranteed to have the best available precision, and is also possibly non-monotonic if the system clock changes between calls (see [docs](https://docs.python.org/3/library/time.html#time.time)). `time.perf_counter` is generally more suitable for measuring runtimes. I've also been using this change locally so it's at least a bit tested.