### PR TITLE
Initialize generator cli args to host/defaults then override

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -588,13 +588,15 @@ def get_random_value(name, option):
     return option.default
 
 
-def call_generate(yaml_path, args, output_path):
+def call_generate(yaml_path, fuzz_args, output_path):
     from settings import get_settings
+    from Generate import mystery_argparse
 
     settings = get_settings()
+    args = mystery_argparse([])
 
-    args = Namespace(
-        **{
+    vars(args).update(
+        {
             "weights_file_path": settings.generator.weights_file_path,
             "sameoptions": False,
             "player_files_path": yaml_path,
@@ -608,7 +610,7 @@ def call_generate(yaml_path, args, output_path):
             "yaml_output": 1,
             "plando": PlandoOptions.items | PlandoOptions.connections | PlandoOptions.texts | PlandoOptions.bosses,
             "skip_prog_balancing": False,
-            "skip_output": args.skip_output,
+            "skip_output": fuzz_args.skip_output,
             "csv_output": False,
             "log_time": False,
             "spoiler_only": False,


### PR DESCRIPTION
See https://github.com/ArchipelagoMW/Archipelago/commit/15561e1e2d0192a2326f9d3e0c0c9165255170a1
The absence of the new `allow_quantity` causes generation calls to fail:
```
  File "Generate.py", line 128, in main
    allow_quantity = args.allow_quantity
                     ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'allow_quantity'
```

The host/default settings via `Generate.mystery_argparse([])` are used then updated with the overrides.
This is the existing behavior but fixed. `allow_quantity` could be added to the overrides and future args would automatically be included.

`call_generate` is not a good place for it, but a difference of the before and after can inform which values were not overridden.